### PR TITLE
Add ability to choose a project

### DIFF
--- a/src/importIssues.ts
+++ b/src/importIssues.ts
@@ -112,10 +112,7 @@ export const importIssues = async (apiKey: string, importer: Importer) => {
         }));
       },
       when: answers => {
-        if (!answers.includeProject || !answers.targetTeamId) return false;
-
-        const projects = getTeamProjects(answers.targetTeamId, teams);
-        return projects.length > 0;
+        return answers.includeProject;
       },
     },
     {

--- a/src/utils/getTeamProjects.ts
+++ b/src/utils/getTeamProjects.ts
@@ -1,0 +1,25 @@
+interface Team {
+  id: string;
+  name: string;
+  key: string;
+  projects: {
+    id: string;
+    name: string;
+    key: string;
+  }[];
+}
+
+/**
+ * Given a list of teams and a team id, get the list of projects
+ * associated with that team.
+ *
+ * @param teamId id of the team to get projects from
+ * @param teams list of teams to check for the given team id
+ *
+ * @returns list of projects for the given team
+ */
+export const getTeamProjects = (teamId: string, teams: Team[]) => {
+  const teamIndex = teams.findIndex(team => team.id === teamId);
+  const projects = teamIndex >= 0 ? teams[teamIndex].projects : [];
+  return projects;
+};


### PR DESCRIPTION
## Purpose
My team needs to bulk import issues into a specific project.

## Approach
If the user chooses to use an existing team, they will be prompted with the option to select a project to import into. If the user selects `yes` then we query for all projects of the previously selected team and display them as list options.

If a project is chosen then the issues get imported to the specific project.