### PR TITLE
Handle missing Jira CSV export 'Description' field gracefully

### DIFF
--- a/src/importers/asanaCsv/index.ts
+++ b/src/importers/asanaCsv/index.ts
@@ -29,7 +29,7 @@ const questions = [
     type: 'input',
     name: 'asanaUrlName',
     message:
-      'Input the URL of your Asana board (e.g. https://app.asana.com/0/123456789/list): ',
+      'Input the URL of your Asana board (e.g. https://app.asana.com/0/123456789/list):',
     validate: (input: string) => {
       return !!input.match(ASANA_URL_REGEX);
     },

--- a/src/importers/jiraCsv/JiraCsvImporter.ts
+++ b/src/importers/jiraCsv/JiraCsvImporter.ts
@@ -65,10 +65,15 @@ export class JiraCsvImporter implements Importer {
       const url = this.organizationName
         ? `https://${this.organizationName}.atlassian.net/browse/${row['Issue key']}`
         : undefined;
-      const mdDesc = j2m.to_markdown(row['Description']);
-      const description = url
-        ? `${mdDesc}\n\n[View original issue in Jira](${url})`
-        : mdDesc;
+      const mdDesc = row['Description']
+        ? j2m.to_markdown(row['Description'])
+        : undefined;
+      const description =
+        mdDesc && url
+          ? `${mdDesc}\n\n[View original issue in Jira](${url})`
+          : url
+          ? `[View original issue in Jira](${url})`
+          : undefined;
       const priority = mapPriority(row['Priority']);
       const type = `Type: ${row['Issue Type']}`;
       const release =

--- a/src/importers/jiraCsv/index.ts
+++ b/src/importers/jiraCsv/index.ts
@@ -29,7 +29,7 @@ const questions = [
     type: 'input',
     name: 'jiraUrlName',
     message:
-      'Input the URL of your Jira installation (e.g. https://acme.atlassian.net): ',
+      'Input the URL of your Jira installation (e.g. https://acme.atlassian.net):',
     validate: (input: string) => {
       return !!input.match(JIRA_URL_REGEX);
     },


### PR DESCRIPTION
Whether the Description field exists in the export depends on if the export was done with "Current fields" or "All fields":
<img width="283" alt="Screenshot 2020-07-10 at 8 45 47" src="https://user-images.githubusercontent.com/299644/87121203-f2065c80-c28a-11ea-861a-cdc81c6dd496.png">

Test ran this with the original problematic import, as well as two of my own, with different export options, should be all good.
