### PR TITLE
Add URL to Jira description

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Following fields are supported:
 
 - `Summary` - Issue title
 - `Description` - Converted into markdown and used as issue description
+- `URL` - URL of Jira issue
 - `Priority` - Issue priority
 - `Issue Type` - Added as a label
 - (Optional) `Release` - Added as a label


### PR DESCRIPTION
Explicitly mention original Jira issue URL is imported into the description