### PR TITLE
Adding ability to use on prem Jira URLs in Jira importer

### DIFF
--- a/src/importers/jiraCsv/JiraCsvImporter.ts
+++ b/src/importers/jiraCsv/JiraCsvImporter.ts
@@ -65,7 +65,7 @@ export class JiraCsvImporter implements Importer {
     for (const row of data) {
       const url = this.organizationName
         ? `https://${this.organizationName}.atlassian.net/browse/${row['Issue key']}`
-        : `${this.customJiraUrl}${row['Issue key']}`;
+        : `${this.customJiraUrl}/browse/${row['Issue key']}`;
       const mdDesc = row['Description']
         ? j2m.to_markdown(row['Description'])
         : undefined;

--- a/src/importers/jiraCsv/JiraCsvImporter.ts
+++ b/src/importers/jiraCsv/JiraCsvImporter.ts
@@ -24,9 +24,10 @@ interface JiraIssueType {
  * @param apiKey GitHub api key for authentication
  */
 export class JiraCsvImporter implements Importer {
-  public constructor(filePath: string, orgSlug: string) {
+  public constructor(filePath: string, orgSlug: string, customUrl: string) {
     this.filePath = filePath;
     this.organizationName = orgSlug;
+    this.customJiraUrl = customUrl;
   }
 
   public get name() {
@@ -64,7 +65,7 @@ export class JiraCsvImporter implements Importer {
     for (const row of data) {
       const url = this.organizationName
         ? `https://${this.organizationName}.atlassian.net/browse/${row['Issue key']}`
-        : undefined;
+        : `${this.customJiraUrl}${row['Issue key']}`;
       const mdDesc = row['Description']
         ? j2m.to_markdown(row['Description'])
         : undefined;
@@ -116,6 +117,7 @@ export class JiraCsvImporter implements Importer {
   // -- Private interface
 
   private filePath: string;
+  private customJiraUrl: string;
   private organizationName?: string;
 }
 

--- a/src/importers/jiraCsv/index.ts
+++ b/src/importers/jiraCsv/index.ts
@@ -22,6 +22,7 @@ export const jiraCsvImport = async (): Promise<Importer> => {
 
 interface JiraImportAnswers {
   jiraFilePath: string;
+  isCloud: boolean;
   customJiraUrl: string;
   jiraUrlName: string;
 }
@@ -34,18 +35,34 @@ const questions = [
     message: 'Select your exported CSV file of Jira issues',
   },
   {
+    type: 'confirm',
+    name: 'isCloud',
+    message:
+      'Is your Jira installation on Jira Cloud (url similar to https://acme.atlassian.net)?',
+    default: true,
+  },
+  {
     type: 'input',
     name: 'customJiraUrl',
     message:
-      'Input the URL of your Jira installation if it is on-prem (e.g. https://jira.mydomain.com), or leave blank if not:',
+      'Input the URL of your on-prem Jira installation (e.g. https://jira.mydomain.com):',
+    when: (answers: JiraImportAnswers) => {
+      return !answers.isCloud;
+    },
+    validate: (input: string) => {
+      return input !== '';
+    },
   },
   {
     type: 'input',
     name: 'jiraUrlName',
     message:
-      'Input the URL of your Jira installation (e.g. https://acme.atlassian.net):',
+      'Input the URL of your Jira Cloud installation (e.g. https://acme.atlassian.net):',
+    when: (answers: JiraImportAnswers) => {
+      return answers.isCloud;
+    },
     validate: (input: string) => {
-      return input === '' || !!input.match(JIRA_URL_REGEX);
+      return !!input.match(JIRA_URL_REGEX);
     },
   },
 ];

--- a/src/importers/jiraCsv/index.ts
+++ b/src/importers/jiraCsv/index.ts
@@ -8,13 +8,21 @@ const JIRA_URL_REGEX = /^https?:\/\/(\S+).atlassian.net/;
 
 export const jiraCsvImport = async (): Promise<Importer> => {
   const answers = await inquirer.prompt<JiraImportAnswers>(questions);
-  const orgSlug = answers.jiraUrlName.match(JIRA_URL_REGEX)![1];
-  const jiraImporter = new JiraCsvImporter(answers.jiraFilePath, orgSlug);
+  let orgSlug = '';
+  if (answers.jiraUrlName) {
+    orgSlug = answers.jiraUrlName.match(JIRA_URL_REGEX)![1];
+  }
+  const jiraImporter = new JiraCsvImporter(
+    answers.jiraFilePath,
+    orgSlug,
+    answers.customJiraUrl
+  );
   return jiraImporter;
 };
 
 interface JiraImportAnswers {
   jiraFilePath: string;
+  customJiraUrl: string;
   jiraUrlName: string;
 }
 
@@ -27,11 +35,17 @@ const questions = [
   },
   {
     type: 'input',
+    name: 'customJiraUrl',
+    message:
+      'Input the URL of your Jira installation if it is on-prem (e.g. https://jira.mydomain.com), or leave blank if not:',
+  },
+  {
+    type: 'input',
     name: 'jiraUrlName',
     message:
       'Input the URL of your Jira installation (e.g. https://acme.atlassian.net):',
     validate: (input: string) => {
-      return !!input.match(JIRA_URL_REGEX);
+      return input === '' || !!input.match(JIRA_URL_REGEX);
     },
   },
 ];


### PR DESCRIPTION
Fixes #44 

# Changes
* Taking in Jira hosted urls in the cli
* Using the Jira hosted url in the importer instead of the org slug

# To test:
1. Clone the linear-import repo `git clone https://github.com/linearapp/linear-import.git`
2. Checkout this branch `git checkout raissa/lin-4029-fix-importer-to-import-issues-from-jira`
3. Run `yarn build`
4. Run `yarn cli` and follow the prompts